### PR TITLE
VMDCONVERTER: fixed grammer issue

### DIFF
--- a/src/main/resources/dev/samir/vmdconverter/vmdconverter.fxml
+++ b/src/main/resources/dev/samir/vmdconverter/vmdconverter.fxml
@@ -30,7 +30,7 @@
                   <Font name="System Bold" size="12.0" />
                </font>
             </Label>
-            <Label layoutX="-15.0" layoutY="6.0" prefHeight="17.0" prefWidth="63.0" text="VMD Flie:" textAlignment="CENTER">
+            <Label layoutX="-15.0" layoutY="6.0" prefHeight="17.0" prefWidth="63.0" text="VMD File:" textAlignment="CENTER">
                <font>
                   <Font name="System Bold" size="12.0" />
                </font>


### PR DESCRIPTION
This fixes a grammer issue

in line 33 text="VMD Flie" to "VMD File"